### PR TITLE
Die gracefully

### DIFF
--- a/kll.py
+++ b/kll.py
@@ -552,9 +552,11 @@ def processKLLFile( filename ):
 		data = file.read()
 		tokenSequence = tokenize( data )
 		#print ( pformat( tokenSequence ) ) # Display tokenization
-		tree = parse( tokenSequence )
-
-
+		try:
+			tree = parse( tokenSequence )
+		except NoParseError as e:
+			print("Error parsing %s. %s" % (filename, e.msg), file=sys.stderr)
+			sys.exit(1)
 
 ### Main Entry Point ###
 


### PR DESCRIPTION
Don't explode into a 20 line stack trace if the kll file is formatted
incorrectly. Instead simply show the error message and exit with an
error code (which will stop the rest of a make command).

A misformatted file is most likely a user error so showing the full
backtrace for debugging is not necessary. The file and line number
should (hopefully) be enough to fix the parsing error.